### PR TITLE
net-p2p/monero: missing cstdint includes, required for recent builds

### DIFF
--- a/net-p2p/monero/files/monero-0.18.2.2-cstdint.patch
+++ b/net-p2p/monero/files/monero-0.18.2.2-cstdint.patch
@@ -1,0 +1,60 @@
+From c32befe4f8385f5f893c0db611060bc7c7b425f3 Mon Sep 17 00:00:00 2001
+From: tobtoht <tob@featherwallet.org>
+Date: Sat, 6 May 2023 18:13:18 +0200
+Subject: [PATCH] fix missing <cstdint> includes
+
+---
+ contrib/epee/include/file_io_utils.h                | 1 +
+ contrib/epee/include/storages/parserse_base_utils.h | 1 +
+ src/common/combinator.h                             | 1 +
+ src/wallet/api/wallet2_api.h                        | 1 +
+ 4 files changed, 4 insertions(+)
+
+diff --git a/contrib/epee/include/file_io_utils.h b/contrib/epee/include/file_io_utils.h
+index da05520c1b9..de95e58c3ea 100644
+--- a/contrib/epee/include/file_io_utils.h
++++ b/contrib/epee/include/file_io_utils.h
+@@ -29,6 +29,7 @@
+ 
+ #include <string>
+ #include <ctime>
++#include <cstdint>
+ 
+ namespace epee
+ {
+diff --git a/contrib/epee/include/storages/parserse_base_utils.h b/contrib/epee/include/storages/parserse_base_utils.h
+index 898813ff9fd..4658eba77ad 100644
+--- a/contrib/epee/include/storages/parserse_base_utils.h
++++ b/contrib/epee/include/storages/parserse_base_utils.h
+@@ -30,6 +30,7 @@
+ 
+ #include <boost/utility/string_ref_fwd.hpp>
+ #include <string>
++#include <cstdint>
+ 
+ namespace epee 
+ {
+diff --git a/src/common/combinator.h b/src/common/combinator.h
+index cb237ed8d40..6ef244a1ed1 100644
+--- a/src/common/combinator.h
++++ b/src/common/combinator.h
+@@ -34,6 +34,7 @@
+ #include <iostream>
+ #include <vector>
+ #include <stdexcept>
++#include <cstdint>
+ 
+ namespace tools {
+ 
+diff --git a/src/wallet/api/wallet2_api.h b/src/wallet/api/wallet2_api.h
+index ab3d9732e8f..df86da847ea 100644
+--- a/src/wallet/api/wallet2_api.h
++++ b/src/wallet/api/wallet2_api.h
+@@ -38,6 +38,7 @@
+ #include <ctime>
+ #include <iostream>
+ #include <stdexcept>
++#include <cstdint>
+ 
+ //  Public interface for libwallet library
+ namespace Monero {

--- a/net-p2p/monero/monero-0.18.2.2.ebuild
+++ b/net-p2p/monero/monero-0.18.2.2.ebuild
@@ -42,6 +42,7 @@ BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-0.18.1.2-unbundle-dependencies.patch"
+	"${FILESDIR}/${P}-csdint.patch"
 )
 
 src_configure() {


### PR DESCRIPTION
Upstream patch:
https://github.com/monero-project/monero/commit/c32befe4f8385f5f893c0db611060bc7c7b425f3