### PR TITLE
mautrix-signal 0.6 needs libsignal-ffi 0.44.0

### DIFF
--- a/net-im/mautrix-signal/mautrix-signal-0.6.0.ebuild
+++ b/net-im/mautrix-signal/mautrix-signal-0.6.0.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
-	dev-libs/libsignal-ffi
+	=dev-libs/libsignal-ffi-0.44.0
 	dev-libs/olm
 "
 

--- a/net-im/mautrix-signal/mautrix-signal-0.6.1.ebuild
+++ b/net-im/mautrix-signal/mautrix-signal-0.6.1.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
-	dev-libs/libsignal-ffi
+	=dev-libs/libsignal-ffi-0.44.0
 	dev-libs/olm
 "
 


### PR DESCRIPTION
mautrix-signal 0.6.0 (and 0.6.1) need libsignal 0.44.0 (and not 0.46.0 which is also available); see [CHANGELOG.md:13](https://github.com/mautrix/signal/blob/v0.6.1/CHANGELOG.md?plain=1#L13) and [pkg/libsignalgo/version.go:5](https://github.com/mautrix/signal/blob/v0.6.1/pkg/libsignalgo/version.go#L5).

Having the wrong version of libsignal-ffi will lead to "Verification failure in zkgroup" or "ZkGroupDeserializationFailure" errors as described in https://github.com/mautrix/signal/issues/483 and https://github.com/mautrix/signal/issues/487.