### PR TITLE
app-text/sioyek: move configutation files

### DIFF
--- a/app-text/sioyek/sioyek-9999.ebuild
+++ b/app-text/sioyek/sioyek-9999.ebuild
@@ -61,7 +61,7 @@ src_install() {
 
 	domenu "${FILESDIR}/sioyek.desktop"
 	doicon resources/sioyek-icon-linux.png
-	insinto /usr/share/sioyek && doins tutorial.pdf pdf_viewer/keys.config pdf_viewer/prefs.config
+	insinto /opt/sioyek && doins tutorial.pdf pdf_viewer/keys.config pdf_viewer/prefs.config
 	doman resources/sioyek.1
 }
 


### PR DESCRIPTION
If installed in /usr/share/sioyek, the configuration files are not picked up by default which results in e.g. non-functioning keybindings. See https://github.com/ahrm/sioyek/issues/1102