### PR TITLE
Revert commit causing nsxiv digest mismatch

### DIFF
--- a/media-gfx/nsxiv/nsxiv-32.ebuild
+++ b/media-gfx/nsxiv/nsxiv-32.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://codeberg.org/nsxiv/nsxiv.git"
 	inherit git-r3
 else
-	SRC_URI="https://codeberg.org/nsxiv/nsxiv/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	SRC_URI="https://github.com/nsxiv/nsxiv/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64"
 fi
 

--- a/media-gfx/nsxiv/nsxiv-9999.ebuild
+++ b/media-gfx/nsxiv/nsxiv-9999.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://codeberg.org/nsxiv/nsxiv.git"
 	inherit git-r3
 else
-	SRC_URI="https://codeberg.org/nsxiv/nsxiv/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	SRC_URI="https://github.com/nsxiv/nsxiv/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64"
 fi
 


### PR DESCRIPTION
This reverts commit 191ef3728606b5f7213e13b5f175dc29e8fe06d6.

I'm not sure why https://github.com/gentoo-mirror/guru/commit/191ef3728606b5f7213e13b5f175dc29e8fe06d6 was made, but it caused the digest of nsxiv to mismatch.

Here is the error message I got:
```
2024-06-26 22:40:00 (103 KB/s) - ‘/var/cache/distfiles/nsxiv-32.tar.gz.__download__’ saved [74338/74338]

!!! Fetched file: nsxiv-32.tar.gz VERIFY FAILED!
!!! Reason: Filesize does not match recorded size
!!! Got:      74338
!!! Expected: 74345
Refetching... File renamed to '/var/cache/distfiles/nsxiv-32.tar.gz._checksum_failure_.sikaonix'

!!! Couldn't download 'nsxiv-32.tar.gz'. Aborting.

>>> Failed to emerge media-gfx/nsxiv-32, Log file:
```

After updated the digest, the following error was shown:
```
>>> Unpacking source...
>>> Unpacking nsxiv-32.tar.gz to /var/tmp/portage/media-gfx/nsxiv-32/work
>>> Source unpacked in /var/tmp/portage/media-gfx/nsxiv-32/work
 * ERROR: media-gfx/nsxiv-32::guru failed (prepare phase):
 *   The source directory '/var/tmp/portage/media-gfx/nsxiv-32/work/nsxiv-32' doesn't exist
 *
 * Call stack:
 *            ebuild.sh, line  784:  Called __ebuild_main 'prepare'
 *   phase-functions.sh, line 1072:  Called __dyn_prepare
 *   phase-functions.sh, line  400:  Called die
 * The specific snippet of code:
 *              die "The source directory '${S}' doesn't exist"
 *
 * If you need support, post the output of `emerge --info '=media-gfx/nsxiv-32::guru'`,
 * the complete build log and the output of `emerge -pqv '=media-gfx/nsxiv-32::guru'`.
 * The complete build log is located at '/var/tmp/portage/media-gfx/nsxiv-32/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/media-gfx/nsxiv-32/temp/environment'.
 * Working directory: '/var/tmp/portage/media-gfx/nsxiv-32/empty'
 * S: '/var/tmp/portage/media-gfx/nsxiv-32/work/nsxiv-32'

>>> Failed to emerge media-gfx/nsxiv-32, Log file:

>>>  '/var/tmp/portage/media-gfx/nsxiv-32/temp/build.log'

 * Messages for package media-gfx/nsxiv-32:

 * ERROR: media-gfx/nsxiv-32::guru failed (prepare phase):
 *   The source directory '/var/tmp/portage/media-gfx/nsxiv-32/work/nsxiv-32' doesn't exist
 *
 * Call stack:
 *            ebuild.sh, line  784:  Called __ebuild_main 'prepare'
 *   phase-functions.sh, line 1072:  Called __dyn_prepare
 *   phase-functions.sh, line  400:  Called die
 * The specific snippet of code:
 *              die "The source directory '${S}' doesn't exist"
 *
 * If you need support, post the output of `emerge --info '=media-gfx/nsxiv-32::guru'`,
 * the complete build log and the output of `emerge -pqv '=media-gfx/nsxiv-32::guru'`.
 * The complete build log is located at '/var/tmp/portage/media-gfx/nsxiv-32/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/media-gfx/nsxiv-32/temp/environment'.
 * Working directory: '/var/tmp/portage/media-gfx/nsxiv-32/empty'
 * S: '/var/tmp/portage/media-gfx/nsxiv-32/work/nsxiv-32'
```

As stated earlier, I'm not sure why this commit was made, so I've decided to revert it.